### PR TITLE
Fix test form_two_buttons_tests #1

### DIFF
--- a/Test/jdi_uitests_webtests/test/composite/form_two_buttons_tests.py
+++ b/Test/jdi_uitests_webtests/test/composite/form_two_buttons_tests.py
@@ -15,4 +15,4 @@ class FormTwoButtonsTests(InitTests):
 
     def test_submit_spec_button_string(self):
         self.form.submit_form(self.contact, "calculate")
-        Assert.wait_assert_equal(lambda: EpamJDISite.contact_form_page.result.get_text(), "Summary: 3")
+        Assert.wait_assert_equal(lambda: EpamJDISite.contact_form_page.result.get_text(), str(self.contact))


### PR DESCRIPTION
Issue # 1 indicates that the "button_name" parameter is ignored in JDI.web.selenium.elements.composite.form.Form.get_button. It does not cause any errors. But it may be useful in the future. So I decided not to remove the "button_name" parameter. I just fixed an error in the test (form_two_buttons_tests).